### PR TITLE
remove dummy revision numbers

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -24,12 +24,12 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/jinzhu/gorm v1.9.12
 	github.com/lib/pq v1.3.0
-	github.com/BNext-IQT/covid-test-db/models/company v0.0.0-00010101000000-000000000000 // indirect
-	github.com/BNext-IQT/covid-test-db/models/diagnostic v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/diagnostic_target_type v0.0.0-00010101000000-000000000000 // indirect
-	github.com/BNext-IQT/covid-test-db/models/diagnostic_type v0.0.0-00010101000000-000000000000 // indirect
-	github.com/BNext-IQT/covid-test-db/models/pcr_platform v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/poc v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/regulatory_approval_type v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/sample_type v0.0.0-00010101000000-000000000000
+	github.com/BNext-IQT/covid-test-db/models/company v0.0.1 // indirect
+	github.com/BNext-IQT/covid-test-db/models/diagnostic v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/diagnostic_target_type v0.0.1 // indirect
+	github.com/BNext-IQT/covid-test-db/models/diagnostic_type v0.0.1 // indirect
+	github.com/BNext-IQT/covid-test-db/models/pcr_platform v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/poc v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/regulatory_approval_type v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/sample_type v0.0.1
 )

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -25,12 +25,12 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/jinzhu/gorm v1.9.12
-	github.com/BNext-IQT/covid-test-db/models/company v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/diagnostic v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/diagnostic_target_type v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/diagnostic_type v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/pcr_platform v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/poc v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/regulatory_approval_type v0.0.0-00010101000000-000000000000
-	github.com/BNext-IQT/covid-test-db/models/sample_type v0.0.0-00010101000000-000000000000
+	github.com/BNext-IQT/covid-test-db/models/company v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/diagnostic v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/diagnostic_target_type v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/diagnostic_type v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/pcr_platform v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/poc v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/regulatory_approval_type v0.0.1
+	github.com/BNext-IQT/covid-test-db/models/sample_type v0.0.1
 )


### PR DESCRIPTION
get rid of the placeholder version numbers inserted by the go CLI tooling.