### PR TITLE
Removes erroneous n_unique_tests field from dropdown menu

### DIFF
--- a/dash/apps/page_results.py
+++ b/dash/apps/page_results.py
@@ -29,12 +29,15 @@ co_names_filepath = os.path.join(DATA_DIR, co_names_json)
 with open(co_names_filepath) as fi:
   co_name_datafile_dict = json.load(fi)
 
+# Get number of unique tests
+n_unique_tests = co_name_datafile_dict['n_unique_tests']
+
+# Remove key for unique tests from dictionary
+del co_name_datafile_dict['n_unique_tests']
+
 # Get unique company names
 unique_companies = list(co_name_datafile_dict.keys())
 n_unique_companies = len(unique_companies)
-
-# Get number of unique tests
-n_unique_tests = co_name_datafile_dict['n_unique_tests']
 
 # Load initial data for printed table
 data_file_path = os.path.join(COMPANY_DATA_DIR,

--- a/dash/apps/page_table.py
+++ b/dash/apps/page_table.py
@@ -23,6 +23,9 @@ co_names_filepath = os.path.join(DATA_DIR, co_names_json)
 with open(co_names_filepath) as fi:
   co_name_datafile_dict = json.load(fi)
 
+# Remove key for unique tests from dictionary
+del co_name_datafile_dict['n_unique_tests']
+
 # Get unique company names
 unique_companies = list(co_name_datafile_dict.keys())
 n_unique_companies = len(unique_companies)


### PR DESCRIPTION
Removes the n_unique_tests item from the dropdown menu by killing from the internal dictionary after loading value for printout in text.